### PR TITLE
Send reply with real_name if display_name is not provided

### DIFF
--- a/src/events/saveSubmissionReplies.ts
+++ b/src/events/saveSubmissionReplies.ts
@@ -46,7 +46,7 @@ export const saveSubmissionRepliesFunction = async ({
           text: message.text,
           threadTS: message.thread_ts,
           timestamp: message.ts,
-          username: user!.profile!.display_name as string,
+          username: user!.profile!.display_name as string || user!.profile!.real_name as string,
         }
         const replyResponse = await submitReply(reply)
 


### PR DESCRIPTION
- If slack user.display_name is not defined the reply will be sent with user.real_name