### PR TITLE
Refactor: new message event handler

### DIFF
--- a/src/events/__tests__/index.test.ts
+++ b/src/events/__tests__/index.test.ts
@@ -9,6 +9,6 @@ const mockedApp = new App() as jest.Mocked<App>;
 describe('configureAppEvents', () => {
   it('should configure app events correctly', () => {
     configureAppEvents(mockedApp);
-    expect(mockedApp.event).toBeCalledTimes(5);
+    expect(mockedApp.event).toBeCalledTimes(4);
   });
 });

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -3,10 +3,10 @@ import { deleteReplyEvent } from './deleteReply';
 import { greetUserEvent } from './greeting';
 import { modifyReplyEvent } from './modifyReply';
 import { submitWithMessageReaction } from './messageReaction';
-import { mapMessageEventsToHandlers } from './message';
+import subscribeToMessageEvents from './message';
 
 export const configureAppEvents = (app: SlackApp) => {
-  mapMessageEventsToHandlers(app);
+  subscribeToMessageEvents(app);
   greetUserEvent(app);
   modifyReplyEvent(app);
   deleteReplyEvent(app);

--- a/src/events/message/__test__/fixture/messageNewEvent.ts
+++ b/src/events/message/__test__/fixture/messageNewEvent.ts
@@ -1,6 +1,6 @@
 import env from '../../../../config/env.config';
 
-export const validMessageEvent = {
+export const messageNewEvent = {
   client_msg_id: '74138583-456a-465b-82f9-6589141d5cdb',
   type: 'message',
   text: 'AGUANTE RACING 15',

--- a/src/events/message/__test__/newMessage.spec.ts
+++ b/src/events/message/__test__/newMessage.spec.ts
@@ -1,12 +1,12 @@
 import { expect, jest } from '@jest/globals';
 import { Logger } from '@slack/bolt';
 import { WebClient } from '@slack/web-api';
-import { handleSubmissionReply } from '../newMessage';
+import { handleSubmissionReplyNew } from '../messageNew';
 import { validConversationHistoryResponse } from './fixture/validConversationHistoryResponse';
 import { userInfoResponse } from './fixture/userInfoResponse';
-import { validMessageEvent } from './fixture/validMessageEvent';
 import replyApi from '../../../api/marketplace/reply/replyApi';
 import { invalidConversationHistoryResponse } from './fixture/invalidConversationHistoryResponse';
+import { messageNewEvent } from './fixture/MessageNewEvent';
 
 jest.mock('../../../api/marketplace/reply/replyApi');
 
@@ -57,31 +57,31 @@ describe('handleSubmissionReply', () => {
         username: '',
       });
 
-    await handleSubmissionReply({
+    await handleSubmissionReplyNew({
       client: webClientMock,
       // @ts-ignore
-      event: validMessageEvent,
+      message: messageNewEvent,
       logger: loggerMock,
     });
 
     expect(conversationHistoryMock).toHaveBeenCalledTimes(1);
     expect(conversationHistoryMock).toHaveBeenCalledWith({
-      latest: validMessageEvent.thread_ts,
-      channel: validMessageEvent.channel,
+      latest: messageNewEvent.thread_ts,
+      channel: messageNewEvent.channel,
       limit: 1,
       inclusive: true,
     });
 
     expect(userInfoMock).toHaveBeenCalledTimes(1);
     expect(userInfoMock).toHaveBeenCalledWith({
-      user: validMessageEvent.user,
+      user: messageNewEvent.user,
     });
     expect(replyCreateMock).toHaveBeenCalledTimes(1);
     expect(replyCreateMock).toHaveBeenCalledWith({
       authorId: userInfoResponse.user.id,
-      text: validMessageEvent.text!,
-      threadTS: validMessageEvent.thread_ts!,
-      timestamp: validMessageEvent.ts,
+      text: messageNewEvent.text!,
+      threadTS: messageNewEvent.thread_ts!,
+      timestamp: messageNewEvent.ts,
       username: expect.any(String),
     });
     expect(loggerMock.info).toHaveBeenCalledTimes(1);
@@ -97,17 +97,17 @@ describe('handleSubmissionReply', () => {
     const userInfoMock = jest.spyOn(webClientMock.users, 'info');
     const replyCreateMock = jest.spyOn(replyApi, 'create');
 
-    await handleSubmissionReply({
+    await handleSubmissionReplyNew({
       client: webClientMock,
       // @ts-ignore
-      event: validMessageEvent,
+      message: messageNewEvent,
       logger: loggerMock,
     });
 
     expect(conversationHistoryMock).toHaveBeenCalledTimes(1);
     expect(conversationHistoryMock).toHaveBeenCalledWith({
-      latest: validMessageEvent.thread_ts,
-      channel: validMessageEvent.channel,
+      latest: messageNewEvent.thread_ts,
+      channel: messageNewEvent.channel,
       limit: 1,
       inclusive: true,
     });
@@ -127,10 +127,10 @@ describe('handleSubmissionReply', () => {
     const userInfoMock = jest.spyOn(webClientMock.users, 'info');
     const replyCreateMock = jest.spyOn(replyApi, 'create');
 
-    await handleSubmissionReply({
+    await handleSubmissionReplyNew({
       client: webClientMock,
       // @ts-ignore
-      event: validMessageEvent,
+      message: messageNewEvent,
       logger: loggerMock,
     });
 

--- a/src/events/message/__test__/newMessage.spec.ts
+++ b/src/events/message/__test__/newMessage.spec.ts
@@ -6,7 +6,7 @@ import { validConversationHistoryResponse } from './fixture/validConversationHis
 import { userInfoResponse } from './fixture/userInfoResponse';
 import replyApi from '../../../api/marketplace/reply/replyApi';
 import { invalidConversationHistoryResponse } from './fixture/invalidConversationHistoryResponse';
-import { messageNewEvent } from './fixture/MessageNewEvent';
+import { messageNewEvent } from './fixture/messageNewEvent';
 
 jest.mock('../../../api/marketplace/reply/replyApi');
 

--- a/src/events/message/index.ts
+++ b/src/events/message/index.ts
@@ -1,6 +1,8 @@
 import { App as SlackApp } from '@slack/bolt';
-import { handleSubmissionReply } from './newMessage';
+import { handleSubmissionReplyNew } from './messageNew';
 
-export const mapMessageEventsToHandlers = (app: SlackApp) => {
-  app.event('message', handleSubmissionReply);
+const subscribeToMessageEvents = (app: SlackApp) => {
+  app.message(handleSubmissionReplyNew);
 };
+
+export default subscribeToMessageEvents;


### PR DESCRIPTION
# Summary

Refactored how the event handler for new messages is subscribed to the bot.

# Details

* Changed `app.event` to `app.message` for subscribing the new handler. This methods filters events to only accept message events.
* Changed names of some functions and variables to keep the code consistent.