### PR TITLE
Fix: Student submissions by emoji

### DIFF
--- a/src/utils/extractOnlySubmission.ts
+++ b/src/utils/extractOnlySubmission.ts
@@ -7,5 +7,5 @@ export const extractOnlySubmission = (message: string): string => {
     return extractCodeBlockFromSubmission(message);
   }
 
-  return '';
+  return message;
 };


### PR DESCRIPTION
# Summary

Submissions that did not pass validation were replaced by an empty string which the API does not accept, thus failing the submission process.