### PR TITLE
Feature: Extract GitHub link from submission

### DIFF
--- a/src/utils/extractLinkFromSubmission.ts
+++ b/src/utils/extractLinkFromSubmission.ts
@@ -1,0 +1,12 @@
+export const extractLinkFromSubmission = (message: string): string => {
+  const linkRegex = /\bgithub\.com\/\S+\b/;
+  const match = message.match(linkRegex);
+
+  if (match) {
+    const link = match[0];
+
+    return link;
+  }
+
+  return '';
+};

--- a/src/utils/extractOnlySubmission.ts
+++ b/src/utils/extractOnlySubmission.ts
@@ -1,10 +1,17 @@
 import { extractCodeBlockFromSubmission } from './extractCodeBlockFromSubmission';
+import { extractLinkFromSubmission } from './extractLinkFromSubmission';
 
 const isBlockOfCode = (text: string): boolean => text.includes('```');
+
+const isLink = (text: string): boolean => text.includes('github.com');
 
 export const extractOnlySubmission = (message: string): string => {
   if (isBlockOfCode(message)) {
     return extractCodeBlockFromSubmission(message);
+  }
+
+  if (isLink(message)) {
+    return extractLinkFromSubmission(message);
   }
 
   return '';


### PR DESCRIPTION
## Summary

Allows Robotina to only extract and save the GitHub link that students submit in classes after class 5.
<br>

## Details

- Create a helper to extract only the GitHub link from the submission.
<br>

## Evidence

User submission

<img src='https://github.com/r-argentina-programa/robotina/assets/93650566/16362a63-aeb3-4ffa-b98e-b1c879a6e1ef' width=500 />
<br>
<br>

Robotina validates and saves the submission

<img src='https://github.com/r-argentina-programa/robotina/assets/93650566/a8f66388-9ea1-4f8a-85ed-ed5765eec7ba' width=500 />
<br>
<br>

<a href='https://tableplus.com/'>TablePlus</a> saved submission view

<img src='https://github.com/r-argentina-programa/robotina/assets/93650566/e66c2e4d-0ad4-41c8-864b-4ac08dcc7764' width=500 />