### PR TITLE
Feature: Validate Submissions Formats

### DIFF
--- a/src/events/reaction/__test__/handleRobotFaceReaction.spec.ts
+++ b/src/events/reaction/__test__/handleRobotFaceReaction.spec.ts
@@ -440,6 +440,55 @@ describe('handleRobotFaceReaction', () => {
         });
       });
     });
+
+    describe('Formats exceptions', () => {
+      it('should make Robotina respond with a message when the submission has more than one format', async () => {
+        clientMock.conversations.history.mockResolvedValueOnce({
+          ...conversationsHistoryResponse,
+          messages: [
+            // @ts-ignore
+            {
+              ...conversationsHistoryResponse.messages[0],
+              text: 'Hola, aca dejo la tarea https://github.com/r-argentina-programa/robotina \n\n```console.log("Hello World!!!")```',
+            },
+          ],
+        });
+
+        clientMock.users.info.mockResolvedValueOnce(
+          // @ts-ignore
+          usersInfoResponse
+        );
+
+        clientMock.conversations.info.mockResolvedValueOnce(
+          // @ts-ignore
+          conversationsInfoResponse
+        );
+
+        clientMock.chat.getPermalink.mockResolvedValueOnce(
+          // @ts-ignore
+          chatGetPermalinkResponse
+        );
+
+        clientMock.chat.postMessage.mockResolvedValueOnce(
+          // @ts-ignore
+          chatPostMessageResponse
+        );
+
+        await handleRobotFaceReaction({
+          client: clientMock,
+          // @ts-ignore
+          event: messageAuthorEvent,
+          logger: loggerMock,
+        });
+
+        expect(clientMock.chat.postMessage).toBeCalledTimes(1);
+        expect(clientMock.chat.postMessage).toHaveBeenCalledWith({
+          channel: messageAuthorEvent.item.channel,
+          thread_ts: messageAuthorEvent.item.ts,
+          text: `Che <@${usersInfoResponse.user.id}>, estás queriendo subir más de un formato a la vez, subí solo uno. O subis un bloque de código, o subís un link de GitHub.`,
+        });
+      });
+    });
   });
 
   describe('Exceptions', () => {

--- a/src/events/reaction/__test__/handleRobotFaceReaction.spec.ts
+++ b/src/events/reaction/__test__/handleRobotFaceReaction.spec.ts
@@ -370,6 +370,48 @@ describe('handleRobotFaceReaction', () => {
           text: `<@${messageAuthorEvent.user}> el formato de la entrega no es válido, si estás en la clase 4 o menos tenés que enviar la tarea como bloque de código y a partir de la clase 5 tenés que enviar el link de github..`,
         });
       });
+
+      it('should make Robotina respond with a message when there is multiple blocks of code', async () => {
+        clientMock.conversations.history.mockResolvedValueOnce({
+          ...conversationsHistoryResponse,
+          messages: [
+            // @ts-ignore
+            {
+              ...conversationsHistoryResponse.messages[0],
+              text: 'Hola, aca dejo la tarea 1 \n\n```console.log("Hello World 1!!!")``` \nY Y acá dejo la tarea 2 \n\n```console.log("Hello World 2!!!")```',
+            },
+          ],
+        });
+
+        clientMock.users.info.mockResolvedValueOnce(
+          // @ts-ignore
+          usersInfoResponse
+        );
+
+        clientMock.conversations.info.mockResolvedValueOnce(
+          // @ts-ignore
+          conversationsInfoResponse
+        );
+
+        clientMock.chat.postMessage.mockResolvedValueOnce(
+          // @ts-ignore
+          chatPostMessageResponse
+        );
+
+        await handleRobotFaceReaction({
+          client: clientMock,
+          // @ts-ignore
+          event: messageAuthorEvent,
+          logger: loggerMock,
+        });
+
+        expect(clientMock.chat.postMessage).toBeCalledTimes(1);
+        expect(clientMock.chat.postMessage).toHaveBeenCalledWith({
+          channel: messageAuthorEvent.item.channel,
+          thread_ts: messageAuthorEvent.item.ts,
+          text: `<@${usersInfoResponse.user.id}> asegurate de mandar la tarea en un solo bloque de código, no en varios. Para ayudarte un poco, podés divirlo algo así: \`\`\`Tarea 1\n console.log("tarea 1")\n\n Tarea 2\n console.log("tarea 2")\`\`\``,
+        });
+      });
     });
 
     describe('GitHub link type', () => {
@@ -437,6 +479,48 @@ describe('handleRobotFaceReaction', () => {
           firstName: expect.any(String),
           lastName: expect.any(String),
           email: expect.any(String),
+        });
+      });
+
+      it('should make Robotina respond with a message when there is multiple GitHub links', async () => {
+        clientMock.conversations.history.mockResolvedValueOnce({
+          ...conversationsHistoryResponse,
+          messages: [
+            // @ts-ignore
+            {
+              ...conversationsHistoryResponse.messages[0],
+              text: 'Hola, aca dejo la tarea 1 https://github.com/r-argentina-programa/robotina1 \n\nY acá dejo la tarea 2 https://github.com/r-argentina-programa/robotina2',
+            },
+          ],
+        });
+
+        clientMock.users.info.mockResolvedValueOnce(
+          // @ts-ignore
+          usersInfoResponse
+        );
+
+        clientMock.conversations.info.mockResolvedValueOnce(
+          // @ts-ignore
+          conversationsInfoResponse
+        );
+
+        clientMock.chat.postMessage.mockResolvedValueOnce(
+          // @ts-ignore
+          chatPostMessageResponse
+        );
+
+        await handleRobotFaceReaction({
+          client: clientMock,
+          // @ts-ignore
+          event: messageAuthorEvent,
+          logger: loggerMock,
+        });
+
+        expect(clientMock.chat.postMessage).toBeCalledTimes(1);
+        expect(clientMock.chat.postMessage).toHaveBeenCalledWith({
+          channel: messageAuthorEvent.item.channel,
+          thread_ts: messageAuthorEvent.item.ts,
+          text: `<@${usersInfoResponse.user.id}> asegurate de mandar la tarea en un solo link de GitHub, no en varios.`,
         });
       });
     });

--- a/src/events/reaction/__test__/handleRobotFaceReaction.spec.ts
+++ b/src/events/reaction/__test__/handleRobotFaceReaction.spec.ts
@@ -488,6 +488,48 @@ describe('handleRobotFaceReaction', () => {
           text: `Che <@${usersInfoResponse.user.id}>, estás queriendo subir más de un formato a la vez, subí solo uno. O subis un bloque de código, o subís un link de GitHub.`,
         });
       });
+
+      it('should make Robotina respond with a message when the submission format is not valid', async () => {
+        clientMock.conversations.history.mockResolvedValueOnce({
+          ...conversationsHistoryResponse,
+          messages: [
+            // @ts-ignore
+            {
+              ...conversationsHistoryResponse.messages[0],
+              text: 'Hola, aca dejo la tarea \n\n`console.log("Hello World!!!")`',
+            },
+          ],
+        });
+
+        clientMock.users.info.mockResolvedValueOnce(
+          // @ts-ignore
+          usersInfoResponse
+        );
+
+        clientMock.conversations.info.mockResolvedValueOnce(
+          // @ts-ignore
+          conversationsInfoResponse
+        );
+
+        clientMock.chat.postMessage.mockResolvedValueOnce(
+          // @ts-ignore
+          chatPostMessageResponse
+        );
+
+        await handleRobotFaceReaction({
+          client: clientMock,
+          // @ts-ignore
+          event: messageAuthorEvent,
+          logger: loggerMock,
+        });
+
+        expect(clientMock.chat.postMessage).toBeCalledTimes(1);
+        expect(clientMock.chat.postMessage).toHaveBeenCalledWith({
+          channel: messageAuthorEvent.item.channel,
+          thread_ts: messageAuthorEvent.item.ts,
+          text: `<@${usersInfoResponse.user.id}>, el formato que estás usando para entregar tu tarea no es válido o está vacío. \n\n\nLos formatos que tenés que usar son, si estás queriendo entregar una tarea de la clase 4 para abajo, un bloque de código: \`\`\` console.log("tarea") \`\`\` \nO, si estás queriendo entregar una tarea a partir de la clase 5 para arriba, entonces debería ser simplemente un link de GitHub: (https://github.com/...). \n\n\nY también acordate de mandar tu tarea en un solo formato, es decir, bloque de código o link de GitHub, no ambos.`,
+        });
+      });
     });
   });
 

--- a/src/events/reaction/__test__/handleRobotFaceReaction.spec.ts
+++ b/src/events/reaction/__test__/handleRobotFaceReaction.spec.ts
@@ -569,7 +569,7 @@ describe('handleRobotFaceReaction', () => {
         expect(clientMock.chat.postMessage).toHaveBeenCalledWith({
           channel: messageAuthorEvent.item.channel,
           thread_ts: messageAuthorEvent.item.ts,
-          text: `Che <@${usersInfoResponse.user.id}>, estás queriendo subir más de un formato a la vez, subí solo uno. O subis un bloque de código, o subís un link de GitHub.`,
+          text: `Che <@${usersInfoResponse.user.id}>, estás queriendo subir más de un formato a la vez. Intentá enviar tu tarea en uno solo. \n\n\nAcordate que si estás en la clase 4 o menos, tenés que enviar la tarea como bloque de código, y a partir de la clase 5 tenés que enviar el link de GitHub.`,
         });
       });
 

--- a/src/events/reaction/handleRobotFaceReaction.ts
+++ b/src/events/reaction/handleRobotFaceReaction.ts
@@ -11,6 +11,7 @@ import { CreateThreadDto } from '../../api/marketplace/thread/dto/CreateThreadDt
 import threadApi from '../../api/marketplace/thread/threadApi';
 import env from '../../config/env.config';
 import { extractOnlySubmission } from '../../utils/extractOnlySubmission';
+import { validateSubmissionSingleFormat } from '../../utils/validateSubmissionSingleFormat';
 
 export const handleRobotFaceReaction: Middleware<
   SlackEventMiddlewareArgs<'reaction_added'>,
@@ -112,6 +113,19 @@ export const handleRobotFaceReaction: Middleware<
         throw new Error(
           'Channel name must be in the format "clase-<number>" or "clase-react-<number>".'
         );
+      }
+
+      const submissionHasSingleFormat = validateSubmissionSingleFormat(
+        reactedMessage.text!
+      );
+
+      if (!submissionHasSingleFormat) {
+        await client.chat.postMessage({
+          channel: event.item.channel,
+          thread_ts: event.item.ts,
+          text: `Che <@${slackUser.id}>, estás queriendo subir más de un formato a la vez, subí solo uno. O subis un bloque de código, o subís un link de GitHub.`,
+        });
+        return;
       }
 
       const validSubmissionFormat = validateSubmissionDeliveryFormat({

--- a/src/events/reaction/handleRobotFaceReaction.ts
+++ b/src/events/reaction/handleRobotFaceReaction.ts
@@ -138,7 +138,7 @@ export const handleRobotFaceReaction: Middleware<
         await client.chat.postMessage({
           channel: event.item.channel,
           thread_ts: event.item.ts,
-          text: `Che <@${slackUser.id}>, estás queriendo subir más de un formato a la vez, subí solo uno. O subis un bloque de código, o subís un link de GitHub.`,
+          text: `Che <@${slackUser.id}>, estás queriendo subir más de un formato a la vez. Intentá enviar tu tarea en uno solo. \n\n\nAcordate que si estás en la clase 4 o menos, tenés que enviar la tarea como bloque de código, y a partir de la clase 5 tenés que enviar el link de GitHub.`,
         });
         return;
       }

--- a/src/events/reaction/handleRobotFaceReaction.ts
+++ b/src/events/reaction/handleRobotFaceReaction.ts
@@ -13,6 +13,7 @@ import env from '../../config/env.config';
 import { extractOnlySubmission } from '../../utils/extractOnlySubmission';
 import { validateSubmissionSingleFormat } from '../../utils/validateSubmissionSingleFormat';
 import { validateSubmissionFormat } from '../../utils/validateSubmissionFormat';
+import { validateNotMultipleSubmissions } from '../../utils/validateNotMultipleSubmissions';
 
 export const handleRobotFaceReaction: Middleware<
   SlackEventMiddlewareArgs<'reaction_added'>,
@@ -138,6 +139,34 @@ export const handleRobotFaceReaction: Middleware<
           channel: event.item.channel,
           thread_ts: event.item.ts,
           text: `Che <@${slackUser.id}>, estás queriendo subir más de un formato a la vez, subí solo uno. O subis un bloque de código, o subís un link de GitHub.`,
+        });
+        return;
+      }
+
+      const validateIsNotMultipleSubmissions = validateNotMultipleSubmissions(
+        reactedMessage.text!
+      );
+
+      if (
+        !validateIsNotMultipleSubmissions &&
+        reactedMessage.text!.includes('```')
+      ) {
+        await client.chat.postMessage({
+          channel: event.item.channel,
+          thread_ts: event.item.ts,
+          text: `<@${slackUser.id}> asegurate de mandar la tarea en un solo bloque de código, no en varios. Para ayudarte un poco, podés divirlo algo así: \`\`\`Tarea 1\n console.log("tarea 1")\n\n Tarea 2\n console.log("tarea 2")\`\`\``,
+        });
+        return;
+      }
+
+      if (
+        !validateIsNotMultipleSubmissions &&
+        reactedMessage.text!.includes('github.com')
+      ) {
+        await client.chat.postMessage({
+          channel: event.item.channel,
+          thread_ts: event.item.ts,
+          text: `<@${slackUser.id}> asegurate de mandar la tarea en un solo link de GitHub, no en varios.`,
         });
         return;
       }

--- a/src/events/reaction/handleRobotFaceReaction.ts
+++ b/src/events/reaction/handleRobotFaceReaction.ts
@@ -12,6 +12,7 @@ import threadApi from '../../api/marketplace/thread/threadApi';
 import env from '../../config/env.config';
 import { extractOnlySubmission } from '../../utils/extractOnlySubmission';
 import { validateSubmissionSingleFormat } from '../../utils/validateSubmissionSingleFormat';
+import { validateSubmissionFormat } from '../../utils/validateSubmissionFormat';
 
 export const handleRobotFaceReaction: Middleware<
   SlackEventMiddlewareArgs<'reaction_added'>,
@@ -113,6 +114,19 @@ export const handleRobotFaceReaction: Middleware<
         throw new Error(
           'Channel name must be in the format "clase-<number>" or "clase-react-<number>".'
         );
+      }
+
+      const submissionHasValidFormat = validateSubmissionFormat(
+        reactedMessage.text!
+      );
+
+      if (!submissionHasValidFormat) {
+        await client.chat.postMessage({
+          channel: event.item.channel,
+          thread_ts: event.item.ts,
+          text: `<@${slackUser.id}>, el formato que estás usando para entregar tu tarea no es válido o está vacío. \n\n\nLos formatos que tenés que usar son, si estás queriendo entregar una tarea de la clase 4 para abajo, un bloque de código: \`\`\` console.log("tarea") \`\`\` \nO, si estás queriendo entregar una tarea a partir de la clase 5 para arriba, entonces debería ser simplemente un link de GitHub: (https://github.com/...). \n\n\nY también acordate de mandar tu tarea en un solo formato, es decir, bloque de código o link de GitHub, no ambos.`,
+        });
+        return;
       }
 
       const submissionHasSingleFormat = validateSubmissionSingleFormat(

--- a/src/utils/validateNotMultipleSubmissions.ts
+++ b/src/utils/validateNotMultipleSubmissions.ts
@@ -3,7 +3,5 @@ export const validateNotMultipleSubmissions = (message: string) => {
   const gitHubLinkCount = (message.match(/github\.com\/[a-zA-Z]/g) || [])
     .length;
 
-  const hasMultipleSubmissions = blockOfCodeCount <= 1 && gitHubLinkCount <= 1;
-
-  return hasMultipleSubmissions;
+  return blockOfCodeCount === 1 || gitHubLinkCount === 1;
 };

--- a/src/utils/validateNotMultipleSubmissions.ts
+++ b/src/utils/validateNotMultipleSubmissions.ts
@@ -1,0 +1,9 @@
+export const validateNotMultipleSubmissions = (message: string) => {
+  const blockOfCodeCount = (message.match(/```[^`]+```/g) || []).length;
+  const gitHubLinkCount = (message.match(/github\.com\/[a-zA-Z]/g) || [])
+    .length;
+
+  const hasMultipleSubmissions = blockOfCodeCount <= 1 && gitHubLinkCount <= 1;
+
+  return hasMultipleSubmissions;
+};

--- a/src/utils/validateSubmissionFormat.ts
+++ b/src/utils/validateSubmissionFormat.ts
@@ -1,0 +1,9 @@
+export const validateSubmissionFormat = (message: string) => {
+  const hasBlockOfCode = /```[^`]+```/.test(message);
+  const hasGitHubLink = /github\.com\/[a-zA-Z]/.test(message);
+  const hasLineOfCode = /^`([^`]+)`$/gm.test(message);
+
+  const isValidFormat = (hasBlockOfCode || hasGitHubLink) && !hasLineOfCode;
+
+  return isValidFormat;
+};

--- a/src/utils/validateSubmissionFormat.ts
+++ b/src/utils/validateSubmissionFormat.ts
@@ -1,9 +1,6 @@
 export const validateSubmissionFormat = (message: string) => {
   const hasBlockOfCode = /```[^`]+```/.test(message);
   const hasGitHubLink = /github\.com\/[a-zA-Z]/.test(message);
-  const hasLineOfCode = /^`([^`]+)`$/gm.test(message);
 
-  const isValidFormat = (hasBlockOfCode || hasGitHubLink) && !hasLineOfCode;
-
-  return isValidFormat;
+  return hasBlockOfCode || hasGitHubLink;
 };

--- a/src/utils/validateSubmissionSingleFormat.ts
+++ b/src/utils/validateSubmissionSingleFormat.ts
@@ -1,5 +1,5 @@
 export const validateSubmissionSingleFormat = (message: string): boolean => {
-  const codeBlockRegex = /```([\s\S]*?)```/;
+  const codeBlockRegex = /```[^`]+```/;
   const linkRegex = /github\.com\/[a-zA-Z]/;
 
   const containsCodeBlock = codeBlockRegex.test(message);

--- a/src/utils/validateSubmissionSingleFormat.ts
+++ b/src/utils/validateSubmissionSingleFormat.ts
@@ -1,0 +1,17 @@
+export const validateSubmissionSingleFormat = (message: string): boolean => {
+  const codeBlockRegex = /```([\s\S]*?)```/;
+  const linkRegex = /github\.com\/[a-zA-Z]/;
+
+  const containsCodeBlock = codeBlockRegex.test(message);
+  const containsLink = linkRegex.test(message);
+
+  const numResults = [containsCodeBlock, containsLink].filter(
+    (result) => result
+  ).length;
+
+  if (numResults > 1) {
+    return false;
+  }
+
+  return true;
+};


### PR DESCRIPTION
# Summary

Robotina can now validate the submissions further.

- Validates if a message has only one of the currently valid formats (block of code or GitHub link). Any other format like images, empty submissions, line of code, etc; will be automatically rejected.
- Validates if a message does not have multiple formats (i.e. both block of code and GitHub link).
- Validates if a message does not have multiple submissions of the same format (i.e. two blocks of code or two GitHub links).
<br>

# Details

- Create a validator function to detect if a message has any other submission format that is not a block of code or a GitHub link.
- Create a validator function to detect when a message has multiple submission formats.
- Create a validator function to detect if a message has multiple submissions of the same format.
<br>

# Evidence

Submission does not have a valid format

<img src='https://github.com/r-argentina-programa/robotina/assets/93650566/dbaf74ed-7aa6-4792-94d3-f1557d673fdb' width=300 />
<br>
<br>

Submission has multiple formats

<img src='https://github.com/r-argentina-programa/robotina/assets/93650566/82f10c42-52c6-4b1c-ab44-2a4585073af4' width=300 />
<br>
<br>

Submission has multiple submission of the same format

<table>
  <tr>
    <td valign="top">
<img src='https://github.com/r-argentina-programa/robotina/assets/93650566/c1f5dec6-45f6-4581-80f6-24468a8a54e8' width=300 /></td>
    <td valign="top">
<img src='https://github.com/r-argentina-programa/robotina/assets/93650566/f1ff727e-8b23-4b46-84eb-07dad1086ebb' width=300 /></td>
  </tr>
</table>