### PR TITLE
Fix:missing protocol

### DIFF
--- a/src/events/reaction/__test__/handleRobotFaceReaction.spec.ts
+++ b/src/events/reaction/__test__/handleRobotFaceReaction.spec.ts
@@ -415,7 +415,7 @@ describe('handleRobotFaceReaction', () => {
 
     describe('GitHub link type', () => {
       it('should save only the github link from the submission successfully', async () => {
-        const typeLinkText = 'github.com/r-argentina-programa/robotina';
+        const typeLinkText = 'https://github.com/r-argentina-programa/robotina';
 
         const submissionResponseMock = {
           completed: false,

--- a/src/utils/extractLinkFromSubmission.ts
+++ b/src/utils/extractLinkFromSubmission.ts
@@ -1,5 +1,5 @@
 export const extractLinkFromSubmission = (message: string): string => {
-  const linkRegex = /\bgithub\.com\/\S+\b/;
+  const linkRegex = /\bhttps?:\/\/github\.com\/\S+\b/;
   const match = message.match(linkRegex);
 
   if (match) {


### PR DESCRIPTION
## Summary
GitHub links were being saved in the database without the HTTP/HTTPS protocol.

## Details

- Refactor GitHub Link RegExp.

- Refactor variable in test case.