### PR TITLE
Feature: Reply check mark

### DIFF
--- a/src/events/message/__test__/newMessage.spec.ts
+++ b/src/events/message/__test__/newMessage.spec.ts
@@ -22,6 +22,9 @@ jest.mock('@slack/web-api', () => ({
     users: {
       info: jest.fn(),
     },
+    reactions: {
+      add: jest.fn(),
+    },
   })),
 }));
 
@@ -76,6 +79,7 @@ describe('handleSubmissionReply', () => {
     expect(userInfoMock).toHaveBeenCalledWith({
       user: messageNewEvent.user,
     });
+
     expect(replyCreateMock).toHaveBeenCalledTimes(1);
     expect(replyCreateMock).toHaveBeenCalledWith({
       authorId: userInfoResponse.user.id,
@@ -84,6 +88,14 @@ describe('handleSubmissionReply', () => {
       timestamp: messageNewEvent.ts,
       username: expect.any(String),
     });
+
+    expect(webClientMock.reactions.add).toBeCalledTimes(1);
+    expect(webClientMock.reactions.add).toBeCalledWith({
+      channel: messageNewEvent.channel,
+      name: 'white_check_mark',
+      timestamp: messageNewEvent.ts,
+    });
+
     expect(loggerMock.info).toHaveBeenCalledTimes(1);
     expect(loggerMock.error).toHaveBeenCalledTimes(0);
   });

--- a/src/events/message/messageNew.ts
+++ b/src/events/message/messageNew.ts
@@ -47,6 +47,12 @@ export const handleSubmissionReplyNew: Middleware<
 
       const reply = await replyApi.create(createReplyDto);
 
+      await client.reactions.add({
+        channel: message.channel,
+        name: 'white_check_mark',
+        timestamp: message.ts,
+      });
+
       logger.info(
         `Reply with ID "${reply.id}" from user "${
           slackUser!.id


### PR DESCRIPTION
## Summary

Add a 'white_check_mark' reaction to indicate that a comment has been persisted in the database.
<br>

## Evidence

**_Robotina reacts on reply_**
<img src='https://github.com/r-argentina-programa/robotina/assets/93650566/ff8ed9c5-206c-4cb6-8752-7d75ec198400' width='250' />