### PR TITLE
refactor: Reply API endpoints

### DIFF
--- a/src/api/marketplace/reply/__test__/replyApi.spec.ts
+++ b/src/api/marketplace/reply/__test__/replyApi.spec.ts
@@ -89,15 +89,15 @@ describe('Marketplace Reply API', () => {
 
       const expectedResponse = expect.objectContaining(updates);
 
-      const postMock = jest
-        .spyOn(marketplaceClient, 'post')
+      const patchMock = jest
+        .spyOn(marketplaceClient, 'patch')
         .mockResolvedValueOnce({ data: { originalReply, ...updates } });
 
       const response = await replyApi.update(originalReply.timestamp, updates);
 
       expect(response).toEqual(expectedResponse);
-      expect(postMock).toHaveBeenCalledWith(
-        `/api/bot/reply/${originalReply.timestamp}`,
+      expect(patchMock).toHaveBeenCalledWith(
+        `/api/reply/timestamp/${originalReply.timestamp}`,
         updates
       );
     });
@@ -120,8 +120,8 @@ describe('Marketplace Reply API', () => {
 
       const expectedErrorMessage = 'Bad Request';
 
-      const postMock = jest
-        .spyOn(marketplaceClient, 'post')
+      const patchMock = jest
+        .spyOn(marketplaceClient, 'patch')
         .mockRejectedValueOnce(
           new AxiosError(
             undefined,
@@ -143,8 +143,8 @@ describe('Marketplace Reply API', () => {
       await expect(
         replyApi.update(originalReply.timestamp, updates)
       ).rejects.toThrowError(expectedErrorMessage);
-      expect(postMock).toHaveBeenCalledWith(
-        `/api/bot/reply/${originalReply.timestamp}`,
+      expect(patchMock).toHaveBeenCalledWith(
+        `/api/reply/timestamp/${originalReply.timestamp}`,
         updates
       );
     });
@@ -160,7 +160,9 @@ describe('Marketplace Reply API', () => {
 
       await replyApi.remove(timestamp);
 
-      expect(deleteMock).toHaveBeenCalledWith(`/api/bot/reply/${timestamp}`);
+      expect(deleteMock).toHaveBeenCalledWith(
+        `/api/reply/timestamp/${timestamp}`
+      );
     });
 
     it('should throw an error when deleting a reply fails', async () => {
@@ -191,7 +193,9 @@ describe('Marketplace Reply API', () => {
       await expect(replyApi.remove(timestamp)).rejects.toThrowError(
         expectedErrorMessage
       );
-      expect(deleteMock).toHaveBeenCalledWith(`/api/bot/reply/${timestamp}`);
+      expect(deleteMock).toHaveBeenCalledWith(
+        `/api/reply/timestamp/${timestamp}`
+      );
     });
   });
 });

--- a/src/api/marketplace/reply/replyApi.ts
+++ b/src/api/marketplace/reply/replyApi.ts
@@ -33,8 +33,8 @@ export const update = async (
   updates: IUpdateReplyDto
 ): Promise<IReplyResponse> => {
   try {
-    const { data } = await marketplaceClient.post<IReplyResponse>(
-      `/api/bot/reply/${timestamp}`,
+    const { data } = await marketplaceClient.patch<IReplyResponse>(
+      `/api/reply/timestamp/${timestamp}`,
       updates
     );
     return data;
@@ -53,7 +53,7 @@ export const update = async (
 
 export const remove = async (timestamp: string): Promise<void> => {
   try {
-    await marketplaceClient.delete(`/api/bot/reply/${timestamp}`);
+    await marketplaceClient.delete(`/api/reply/timestamp/${timestamp}`);
   } catch (error) {
     if (axios.isAxiosError(error)) {
       console.error('[replyApi Error: Remove]', error.response);


### PR DESCRIPTION
## Summary
When updating and deleting replies, Robotina was previously using the endpoints in the 'Bot' module. This PR refactors update and delete methods  to utilize the newly added 'timestamp' endpoints within the replies API module.

## Details

-In the update method, replaced the 'POST' API call with a 'PATCH' request to align with RESTful architecture principles